### PR TITLE
Extend configuration to allow editing text for login link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+simplesamlphp_auth.code-workspace

--- a/config/simplesamlphp_auth.settings.json
+++ b/config/simplesamlphp_auth.settings.json
@@ -15,5 +15,6 @@
     "roles": [],
     "users": "",
     "logoutgotourl": "",
-    "user_register_original": "1"
+    "user_register_original": "1",
+    "login_link_display_name": "Federated Log In"
 }

--- a/simplesamlphp_auth.admin.inc
+++ b/simplesamlphp_auth.admin.inc
@@ -45,10 +45,10 @@ function simplesamlphp_auth_settings() {
     '#default_value' => $config->get('authsource'),
     '#description' => t('The name of the source to use from /var/simplesamlphp/config/authsources.php'),
   );
-  $form['simplesamlphp_auth_grp_setup']['simplesamlphp_auth_login_link_display_name'] = array(
+  $form['simplesamlphp_auth_grp_setup']['login_link_display_name'] = array(
     '#type' => 'textfield',
     '#title' => t('Federated Log In Link Display Name'),
-    '#default_value' => $config->get('link_display_name'),
+    '#default_value' => $config->get('login_link_display_name'),
     '#description' => t('Text to display as the link to the external federated login page. Default is "Federated Log In" and is passed through the core translation layer.'),
   );  
   $form['simplesamlphp_auth_grp_setup']['forcehttps'] = array(

--- a/simplesamlphp_auth.admin.inc
+++ b/simplesamlphp_auth.admin.inc
@@ -45,13 +45,18 @@ function simplesamlphp_auth_settings() {
     '#default_value' => $config->get('authsource'),
     '#description' => t('The name of the source to use from /var/simplesamlphp/config/authsources.php'),
   );
+  $form['simplesamlphp_auth_grp_setup']['simplesamlphp_auth_login_link_display_name'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Federated Log In Link Display Name'),
+    '#default_value' => variable_get('simplesamlphp_auth_login_link_display_name', 'Federated Log In'),
+    '#description' => t('Text to display as the link to the external federated login page. Default is "Federated Log In" and is passed through the core translation layer.'),
+  );  
   $form['simplesamlphp_auth_grp_setup']['forcehttps'] = array(
     '#type' => 'checkbox',
     '#title' => t('Force https for login links'),
     '#default_value' => $config->get('forcehttps'),
     '#description' => t('Should be enabled on production sites.'),
   );
-
   $form['simplesamlphp_auth_grp_user'] = array(
     '#type' => 'fieldset',
     '#title' => t('User Info and Syncing'),

--- a/simplesamlphp_auth.admin.inc
+++ b/simplesamlphp_auth.admin.inc
@@ -48,7 +48,7 @@ function simplesamlphp_auth_settings() {
   $form['simplesamlphp_auth_grp_setup']['simplesamlphp_auth_login_link_display_name'] = array(
     '#type' => 'textfield',
     '#title' => t('Federated Log In Link Display Name'),
-    '#default_value' => variable_get('simplesamlphp_auth_login_link_display_name', 'Federated Log In'),
+    '#default_value' => $config->get('link_display_name'),
     '#description' => t('Text to display as the link to the external federated login page. Default is "Federated Log In" and is passed through the core translation layer.'),
   );  
   $form['simplesamlphp_auth_grp_setup']['forcehttps'] = array(

--- a/simplesamlphp_auth.install
+++ b/simplesamlphp_auth.install
@@ -70,6 +70,7 @@ function simplesamlphp_auth_update_1000() {
   $config->set('users', update_variable_get('simplesamlphp_auth_users', ''));
   $config->set('logoutgotourl', update_variable_get('simplesamlphp_auth_logoutgotourl', ''));
   $config->set('user_register_original', update_variable_get('simplesamlphp_auth_user_register_original', '1'));
+  $config->set('link_display_name', update_variable_get('simplesamlphp_auth_link_display_name', 'Federated Log In'));
   $config->save();
 
   update_variable_del('activate');
@@ -88,4 +89,5 @@ function simplesamlphp_auth_update_1000() {
   update_variable_del('users');
   update_variable_del('logoutgotourl');
   update_variable_del('user_register_original');
+  update_variable_del('simplesamlphp_auth_link_display_name');
 }

--- a/simplesamlphp_auth.install
+++ b/simplesamlphp_auth.install
@@ -70,7 +70,7 @@ function simplesamlphp_auth_update_1000() {
   $config->set('users', update_variable_get('simplesamlphp_auth_users', ''));
   $config->set('logoutgotourl', update_variable_get('simplesamlphp_auth_logoutgotourl', ''));
   $config->set('user_register_original', update_variable_get('simplesamlphp_auth_user_register_original', '1'));
-  $config->set('link_display_name', update_variable_get('simplesamlphp_auth_link_display_name', 'Federated Log In'));
+  $config->set('login_link_display_name', update_variable_get('simplesamlphp_auth_link_display_name', 'Federated Log In'));
   $config->save();
 
   update_variable_del('activate');
@@ -89,5 +89,5 @@ function simplesamlphp_auth_update_1000() {
   update_variable_del('users');
   update_variable_del('logoutgotourl');
   update_variable_del('user_register_original');
-  update_variable_del('simplesamlphp_auth_link_display_name');
+  update_variable_del('simplesamlphp_auth_login_link_display_name');
 }

--- a/simplesamlphp_auth.install
+++ b/simplesamlphp_auth.install
@@ -91,3 +91,14 @@ function simplesamlphp_auth_update_1000() {
   update_variable_del('user_register_original');
   update_variable_del('simplesamlphp_auth_login_link_display_name');
 }
+
+/**
+ * Ensure a default value for the login link title.
+ */
+function simplesamlphp_auth_update_1200() {
+  $config = config('simplesamlphp_auth.settings');
+  if (empty($config->get('login_link_display_name'))) {
+      $config->set('login_link_display_name', 'Federated Log In');
+      $config->save();
+  }
+}

--- a/simplesamlphp_auth.module
+++ b/simplesamlphp_auth.module
@@ -680,7 +680,7 @@ function _simplesamlphp_auth_generate_block_text() {
     . '<br />' . l(t('Log Out'), 'user/logout') . '</p>';
   }
   else {
-    $block_content .= '<p>' . l(config_get('simplesamlphp_auth.settings', 'login_link_display_name'), 'saml_login') . '</p>';  }
+    $block_content .= '<p>' . l(config_get('simplesamlphp_auth.settings', 'login_link_display_name'), 'saml_login') . '</p>';
   }
 
   return $block_content;

--- a/simplesamlphp_auth.module
+++ b/simplesamlphp_auth.module
@@ -462,7 +462,7 @@ function simplesamlphp_auth_form_alter(&$form, $form_state, $form_id) {
   }
 
   if ($form_id == 'user_login_block') {
-    $$link                     = l(config_get('simplesamlphp_auth.settings', 'login_link_display_name'), 'saml_login');
+    $link                     = l(config_get('simplesamlphp_auth.settings', 'login_link_display_name'), 'saml_login');
     $links                    = $form['links']['#markup'];
     $links                    = str_replace('</ul>', '<li class="saml">' . $link . '</li></ul>', $links);
     $form['links']['#markup'] = $links;

--- a/simplesamlphp_auth.module
+++ b/simplesamlphp_auth.module
@@ -680,7 +680,7 @@ function _simplesamlphp_auth_generate_block_text() {
     . '<br />' . l(t('Log Out'), 'user/logout') . '</p>';
   }
   else {
-    $block_content .= '<p>' . config_get('simplesamlphp_auth.settings', 'login_link_display_name') . '</p>';
+    $block_content .= '<p>' . l(config_get('simplesamlphp_auth.settings', 'login_link_display_name'), 'saml_login') . '</p>';  }
   }
 
   return $block_content;

--- a/simplesamlphp_auth.module
+++ b/simplesamlphp_auth.module
@@ -462,14 +462,14 @@ function simplesamlphp_auth_form_alter(&$form, $form_state, $form_id) {
   }
 
   if ($form_id == 'user_login_block') {
-    $link                     = l(t('Federated Log In'), 'saml_login');
+    $link                     = l($link_display_name, 'saml_login');
     $links                    = $form['links']['#markup'];
     $links                    = str_replace('</ul>', '<li class="saml">' . $link . '</li></ul>', $links);
     $form['links']['#markup'] = $links;
   }
 
   if ($form_id == 'user_account_form') {
-    $link                     = l(t('Federated Log In'), 'saml_login');
+    $link                     = l($link_display_name, 'saml_login');
     $links                    = $form['links']['#markup'];
     $links                    = str_replace('</ul>', '<li class="saml">' . $link . '</li></ul>', $links);
     $form['links']['#markup'] = $links;
@@ -680,7 +680,7 @@ function _simplesamlphp_auth_generate_block_text() {
     . '<br />' . l(t('Log Out'), 'user/logout') . '</p>';
   }
   else {
-    $block_content .= '<p>' . l(t('Federated Log In'), 'saml_login') . '</p>';
+    $block_content .= '<p>' . l($link_display_name, 'saml_login') . '</p>';
   }
 
   return $block_content;

--- a/simplesamlphp_auth.module
+++ b/simplesamlphp_auth.module
@@ -462,14 +462,14 @@ function simplesamlphp_auth_form_alter(&$form, $form_state, $form_id) {
   }
 
   if ($form_id == 'user_login_block') {
-    $link                     = l($link_display_name, 'saml_login');
+    $$link                     = l(config_get('simplesamlphp_auth.settings', 'login_link_display_name'), 'saml_login');
     $links                    = $form['links']['#markup'];
     $links                    = str_replace('</ul>', '<li class="saml">' . $link . '</li></ul>', $links);
     $form['links']['#markup'] = $links;
   }
 
   if ($form_id == 'user_account_form') {
-    $link                     = l($link_display_name, 'saml_login');
+    $link                     = l(config_get('simplesamlphp_auth.settings', 'login_link_display_name'), 'saml_login');
     $links                    = $form['links']['#markup'];
     $links                    = str_replace('</ul>', '<li class="saml">' . $link . '</li></ul>', $links);
     $form['links']['#markup'] = $links;
@@ -680,7 +680,7 @@ function _simplesamlphp_auth_generate_block_text() {
     . '<br />' . l(t('Log Out'), 'user/logout') . '</p>';
   }
   else {
-    $block_content .= '<p>' . l($link_display_name, 'saml_login') . '</p>';
+    $block_content .= '<p>' . config_get('simplesamlphp_auth.settings', 'login_link_display_name') . '</p>';
   }
 
   return $block_content;


### PR DESCRIPTION
Fixes #9     Extend configuration to allow editing text for login link, backport from Drupal 7