### PR TITLE
Issue #9: Extend configuration to allow editing text for login link.

### DIFF
--- a/config/simplesamlphp_auth.settings.json
+++ b/config/simplesamlphp_auth.settings.json
@@ -15,5 +15,6 @@
     "roles": [],
     "users": "",
     "logoutgotourl": "",
-    "user_register_original": "1"
+    "user_register_original": "1",
+    "login_link_display_name": "Federated Login"
 }

--- a/simplesamlphp_auth.admin.inc
+++ b/simplesamlphp_auth.admin.inc
@@ -81,13 +81,13 @@ function simplesamlphp_auth_settings() {
     '#type' => 'textarea',
     '#title' => t('Automatic role population from simpleSAMLphp attributes'),
     '#default_value' => $config->get('rolepopulation'),
-    '#description' => t('A pipe separated list of rules.<br />Example: <i>roleid1:condition1|roleid2:contition2...</i> <br />For instance: <i>1:eduPersonPrincipalName,@=,uninett.no;affiliation,=,employee|2:mail,=,andreas@uninett.no</i>,3:mail,~=,andre'),
+    '#description' => t('A pipe separated list of rules.<br />Example: <i>roleid1:condition1|roleid2:condition2...</i> <br />For instance: <i>1:eduPersonPrincipalName,@=,uninett.no;affiliation,=,employee|2:mail,=,andreas@uninett.no</i>,3:mail,~=,andre'),
   );
   $form['simplesamlphp_auth_grp_user']['roleevaleverytime'] = array(
     '#type' => 'checkbox',
     '#title' => t('Reevaluate roles every time the user logs in.'),
     '#default_value' => $config->get('roleevaleverytime'),
-    '#description' => t('NOTE: This means users could loose any roles that have been assigned manually in Backdrop.'),
+    '#description' => t('NOTE: This means users could lose any roles that have been assigned manually in Backdrop.'),
   );
 
   $form['simplesamlphp_auth_grp_reg'] = array(

--- a/simplesamlphp_auth.admin.inc
+++ b/simplesamlphp_auth.admin.inc
@@ -45,13 +45,19 @@ function simplesamlphp_auth_settings() {
     '#default_value' => $config->get('authsource'),
     '#description' => t('The name of the source to use from /var/simplesamlphp/config/authsources.php'),
   );
+  $display_name = $config->get('login_link_display_name');
+  $form['simplesamlphp_auth_grp_setup']['login_link_display_name'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Federated login link display name'),
+    '#default_value' => ($display_name != 'Federated Login') ? $display_name : t('Federated Login'),
+    '#description' => t('Text to display as the link to the external federated login page. The default is "Federated Login" which is passed through the core translation layer. You can also change the value in the configuration settings.'),
+  );
   $form['simplesamlphp_auth_grp_setup']['forcehttps'] = array(
     '#type' => 'checkbox',
     '#title' => t('Force https for login links'),
     '#default_value' => $config->get('forcehttps'),
     '#description' => t('Should be enabled on production sites.'),
   );
-
   $form['simplesamlphp_auth_grp_user'] = array(
     '#type' => 'fieldset',
     '#title' => t('User Info and Syncing'),

--- a/simplesamlphp_auth.install
+++ b/simplesamlphp_auth.install
@@ -68,6 +68,7 @@ function simplesamlphp_auth_update_1000() {
   $config->set('users', update_variable_get('simplesamlphp_auth_users', ''));
   $config->set('logoutgotourl', update_variable_get('simplesamlphp_auth_logoutgotourl', ''));
   $config->set('user_register_original', update_variable_get('simplesamlphp_auth_user_register_original', '1'));
+  $config->set('login_link_display_name', update_variable_get('simplesamlphp_auth_link_display_name', 'Federated Login'));
   $config->save();
 
   update_variable_del('simplesamlphp_auth_activate');
@@ -86,4 +87,16 @@ function simplesamlphp_auth_update_1000() {
   update_variable_del('simplesamlphp_auth_users');
   update_variable_del('simplesamlphp_auth_logoutgotourl');
   update_variable_del('simplesamlphp_auth_user_register_original');
+  update_variable_del('simplesamlphp_auth_login_link_display_name');
+}
+
+/**
+ * Ensure a default value for the login link title.
+ */
+function simplesamlphp_auth_update_1200() {
+  $config = config('simplesamlphp_auth.settings');
+  if (empty($config->get('login_link_display_name'))) {
+      $config->set('login_link_display_name', 'Federated Login');
+      $config->save();
+  }
 }

--- a/simplesamlphp_auth.module
+++ b/simplesamlphp_auth.module
@@ -9,7 +9,7 @@
  *
  * ISSUES and TODOs:
  *  ISSUE: User is always dropped on user page after login, instead of where
- *         they were when they clicked "Federated Log In". Because of this, deep
+ *         they were when they clicked "Federated Login". Because of this, deep
  *         linking to access controlled content does not work. Usability would
  *         be considerably increased if this were resolved.
  *  FYI: Backdrop now requires knowledge of the local user password in order to
@@ -553,14 +553,14 @@ function simplesamlphp_auth_form_alter(&$form, $form_state, $form_id) {
   }
 
   if ($form_id == 'user_login_block') {
-    $link                     = l(t('Federated Log In'), 'saml_login');
+    $link                     = l(config_get('simplesamlphp_auth.settings', 'login_link_display_name'), 'saml_login');
     $links                    = $form['links']['#markup'];
     $links                    = str_replace('</ul>', '<li class="saml">' . $link . '</li></ul>', $links);
     $form['links']['#markup'] = $links;
   }
 
   if ($form_id == 'user_account_form') {
-    $link                     = l(t('Federated Log In'), 'saml_login');
+    $link                     = l(config_get('simplesamlphp_auth.settings', 'login_link_display_name'), 'saml_login');
     $links                    = $form['links']['#markup'];
     $links                    = str_replace('</ul>', '<li class="saml">' . $link . '</li></ul>', $links);
     $form['links']['#markup'] = $links;
@@ -768,7 +768,7 @@ function _simplesamlphp_auth_generate_block_text() {
     . '<br />' . l(t('Log Out'), 'user/logout') . '</p>';
   }
   else {
-    $block_content .= '<p>' . l(t('Federated Log In'), 'saml_login') . '</p>';
+    $block_content .= '<p>' . l(config_get('simplesamlphp_auth.settings', 'login_link_display_name'), 'saml_login') . '</p>';
   }
 
   return $block_content;


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/simplesamlphp_auth/issues/9
By @irinaz and @laryn, based on work in the 7.x-3.x branch in the Drupal version of this module.